### PR TITLE
Add Alpaca exchange integration

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -307,6 +307,11 @@ Most exchanges supported by CCXT should work out of the box.
 If you need to implement a specific exchange class, these are found in the `freqtrade/exchange` source folder. You'll also need to add the import to `freqtrade/exchange/__init__.py` to make the loading logic aware of the new exchange.  
 We recommend looking at existing exchange implementations to get an idea of what might be required.
 
+!!! Note "Alpaca"
+    Alpaca distinguishes between live and paper trading via different API domains.
+    Set `"paper": true` in the exchange configuration to use the paper endpoint
+    `https://paper-api.alpaca.markets`.
+
 !!! Warning
     Implementing and testing an exchange can be a lot of trial and error, so please bear this in mind.
     You should also have some development experience, as this is not a beginner task.

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -407,6 +407,24 @@ If your account is required to use an operatorId, you can set it in the configur
 
 Bitvavo expects the `operatorId` to be an integer.
 
+## Alpaca
+
+Alpaca supports both live and paper trading. Use the `paper` flag in the
+exchange configuration to select the correct domain.
+
+```json
+"exchange": {
+    "name": "alpaca",
+    "key": "your_api_key_id",
+    "secret": "your_secret_key",
+    "paper": true
+}
+```
+
+When `paper` is enabled, Freqtrade connects to `https://paper-api.alpaca.markets`.
+For live trading set `paper` to `false` and the bot will use
+`https://api.alpaca.markets`.
+
 ## All exchanges
 
 Should you experience constant errors with Nonce (like `InvalidNonce`), it is best to regenerate the API keys. Resetting Nonce is difficult and it's usually easier to regenerate the API keys.

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -4,6 +4,7 @@ from freqtrade.exchange.common import MAP_EXCHANGE_CHILDCLASS
 from freqtrade.exchange.exchange import Exchange
 
 # isort: on
+from freqtrade.exchange.alpaca import Alpaca
 from freqtrade.exchange.binance import Binance
 from freqtrade.exchange.bingx import Bingx
 from freqtrade.exchange.bitmart import Bitmart

--- a/freqtrade/exchange/alpaca.py
+++ b/freqtrade/exchange/alpaca.py
@@ -1,0 +1,32 @@
+"""Alpaca exchange subclass."""
+
+import logging
+
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.exchange_types import FtHas
+
+
+logger = logging.getLogger(__name__)
+
+
+class Alpaca(Exchange):
+    """Alpaca exchange class.
+
+    Contains adjustments needed for Freqtrade to work with this exchange.
+    """
+
+    _ft_has: FtHas = {
+        "ohlcv_candle_limit": 1000,
+    }
+
+    def additional_exchange_init(self) -> None:
+        """Set API domain based on paper trading configuration."""
+        # ``paper`` defaults to True to use the paper trading API
+        paper = self._config.get("paper", True)
+        base_url = "https://paper-api.alpaca.markets" if paper else "https://api.alpaca.markets"
+        try:
+            if hasattr(self._api, "urls"):
+                self._api.urls.setdefault("api", base_url)
+                self._api.urls["api"] = base_url
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Failed to set Alpaca base url: %s", e)

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -52,6 +52,7 @@ MAP_EXCHANGE_CHILDCLASS = {
     "myokx": "okx",
     "gateio": "gate",
     "huboi": "htx",
+    "alpaca": "alpaca",
 }
 
 SUPPORTED_EXCHANGES = [
@@ -64,6 +65,7 @@ SUPPORTED_EXCHANGES = [
     "hyperliquid",
     "kraken",
     "okx",
+    "alpaca",
 ]
 
 # either the main, or replacement methods (array) is required

--- a/tests/exchange/test_alpaca.py
+++ b/tests/exchange/test_alpaca.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+from tests.conftest import get_patched_exchange
+
+
+def test_additional_exchange_init_alpaca(default_conf, mocker):
+    api_mock = MagicMock()
+    api_mock.urls = {}
+    default_conf["exchange"]["paper"] = True
+    get_patched_exchange(mocker, default_conf, api_mock, exchange="alpaca")
+    assert api_mock.urls["api"] == "https://paper-api.alpaca.markets"
+
+    api_mock.urls = {}
+    default_conf["exchange"]["paper"] = False
+    get_patched_exchange(mocker, default_conf, api_mock, exchange="alpaca")
+    assert api_mock.urls["api"] == "https://api.alpaca.markets"

--- a/tests/exchange_online/conftest.py
+++ b/tests/exchange_online/conftest.py
@@ -501,6 +501,13 @@ EXCHANGES = {
         # TODO: re-enable hyperliquid websocket tests
         "skip_ws_tests": True,
     },
+    "alpaca": {
+        "pair": "BTC/USD",
+        "stake_currency": "USD",
+        "hasQuoteVolume": True,
+        "timeframe": "1h",
+        "candle_count": 1000,
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- add Alpaca exchange module
- register Alpaca in exchange mapping and docs
- document Alpaca usage
- add unit test for Alpaca exchange
- allow online tests to check Alpaca

## Testing
- `pre-commit run --files freqtrade/exchange/alpaca.py freqtrade/exchange/__init__.py freqtrade/exchange/common.py docs/exchanges.md docs/developer.md tests/exchange/test_alpaca.py tests/exchange_online/conftest.py`
- `pytest -q tests/exchange/test_alpaca.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68869fa4634c8329996f79250f75963f