### PR TITLE
Add Q-learning classifiers with prioritized replay

### DIFF
--- a/freqtrade/freqai/RL/PrioritizedReplayBuffer.py
+++ b/freqtrade/freqai/RL/PrioritizedReplayBuffer.py
@@ -1,0 +1,81 @@
+import numpy as np
+
+
+class PrioritizedReplayBuffer:
+    """Basic prioritized experience replay buffer.
+
+    Sampling probability of each experience is proportional to its priority.
+    """
+
+    def __init__(
+        self,
+        capacity: int,
+        alpha: float = 0.6,
+        beta: float = 0.4,
+        beta_increment: float = 1e-3,
+        epsilon: float = 1e-6,
+    ) -> None:
+        self.capacity = capacity
+        self.alpha = alpha
+        self.beta = beta
+        self.beta_increment = beta_increment
+        self.epsilon = epsilon
+        self.buffer: list[tuple[np.ndarray, int, float, np.ndarray, bool]] = []
+        self.pos = 0
+        self.priorities = np.zeros((capacity,), dtype=float)
+
+    def add(
+        self,
+        state: np.ndarray,
+        action: int,
+        reward: float,
+        next_state: np.ndarray,
+        done: bool,
+    ) -> None:
+        max_prio = self.priorities.max() if self.buffer else 1.0
+        if len(self.buffer) < self.capacity:
+            self.buffer.append((state, action, reward, next_state, done))
+        else:
+            self.buffer[self.pos] = (state, action, reward, next_state, done)
+        self.priorities[self.pos] = max_prio
+        self.pos = (self.pos + 1) % self.capacity
+
+    def sample(
+        self, batch_size: int
+    ) -> tuple[
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+    ]:
+        if len(self.buffer) == self.capacity:
+            prios = self.priorities
+        else:
+            prios = self.priorities[: self.pos]
+        probs = prios**self.alpha
+        probs /= probs.sum()
+        indices = np.random.choice(len(self.buffer), batch_size, p=probs)
+        samples = [self.buffer[idx] for idx in indices]
+        self.beta = np.min([1.0, self.beta + self.beta_increment])
+        weights = (len(self.buffer) * probs[indices]) ** (-self.beta)
+        weights /= weights.max()
+        states, actions, rewards, next_states, dones = zip(*samples, strict=False)
+        return (
+            np.stack(states),
+            np.array(actions),
+            np.array(rewards, dtype=np.float32),
+            np.stack(next_states),
+            np.array(dones, dtype=np.float32),
+            indices,
+            np.array(weights, dtype=np.float32),
+        )
+
+    def update_priorities(self, indices: np.ndarray, priorities: np.ndarray) -> None:
+        for idx, prio in zip(indices, priorities, strict=False):
+            self.priorities[idx] = prio + self.epsilon
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.buffer)

--- a/freqtrade/freqai/prediction_models/DoubleQLearningClassifier.py
+++ b/freqtrade/freqai/prediction_models/DoubleQLearningClassifier.py
@@ -1,0 +1,95 @@
+import random
+from collections import defaultdict
+from typing import Any
+
+import numpy as np
+
+from freqtrade.freqai.base_models.BaseClassifierModel import BaseClassifierModel
+from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
+
+
+class DoubleQLearningClassifier(BaseClassifierModel):
+    """Double Q-learning classifier."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        cfg = self.freqai_info.get("rl_config", {})
+        self.alpha: float = cfg.get("alpha", 0.1)
+        self.gamma: float = cfg.get("gamma", 0.99)
+        self.epsilon: float = cfg.get("epsilon", 1.0)
+        self.epsilon_decay: float = cfg.get("epsilon_decay", 0.995)
+        self.min_epsilon: float = cfg.get("min_epsilon", 0.01)
+        self.train_cycles: int = cfg.get("train_cycles", 1)
+        self.n_actions: int = 0
+
+    def _epsilon_action(
+        self,
+        state: tuple[float, ...],
+        q1: dict[tuple[float, ...], np.ndarray],
+        q2: dict[tuple[float, ...], np.ndarray],
+    ) -> int:
+        if random.random() < self.epsilon:
+            return random.randrange(self.n_actions)
+        values = q1[state] + q2[state]
+        return int(np.argmax(values))
+
+    def fit(self, data_dictionary: dict[str, Any], dk: FreqaiDataKitchen, **kwargs) -> Any:
+        X = data_dictionary["train_features"].to_numpy()
+        y = data_dictionary["train_labels"].to_numpy()[:, 0].astype(int)
+        self.n_actions = len(np.unique(y))
+        q1: dict[tuple[float, ...], np.ndarray] = defaultdict(lambda: np.zeros(self.n_actions))
+        q2: dict[tuple[float, ...], np.ndarray] = defaultdict(lambda: np.zeros(self.n_actions))
+
+        for _ in range(self.train_cycles):
+            for i in range(len(X) - 1):
+                s_key = tuple(X[i])
+                ns_key = tuple(X[i + 1])
+                action = self._epsilon_action(s_key, q1, q2)
+                reward = 1.0 if action == y[i] else 0.0
+                if random.random() < 0.5:
+                    best_next = int(np.argmax(q1[ns_key]))
+                    q1[s_key][action] += self.alpha * (
+                        reward + self.gamma * q2[ns_key][best_next] - q1[s_key][action]
+                    )
+                else:
+                    best_next = int(np.argmax(q2[ns_key]))
+                    q2[s_key][action] += self.alpha * (
+                        reward + self.gamma * q1[ns_key][best_next] - q2[s_key][action]
+                    )
+            self.epsilon = max(self.min_epsilon, self.epsilon * self.epsilon_decay)
+
+        return _DoubleQPolicy(q1, q2, self.n_actions)
+
+
+class _DoubleQPolicy:
+    """Policy wrapper for double Q-learning tables."""
+
+    def __init__(
+        self,
+        q1: dict[tuple[float, ...], np.ndarray],
+        q2: dict[tuple[float, ...], np.ndarray],
+        n_actions: int,
+    ) -> None:
+        self.q1 = q1
+        self.q2 = q2
+        self.n_actions = n_actions
+        self.classes_ = np.arange(n_actions)
+
+    def _get_q(self, state: tuple[float, ...]) -> np.ndarray:
+        q1_val = self.q1.get(state, np.zeros(self.n_actions))
+        q2_val = self.q2.get(state, np.zeros(self.n_actions))
+        return q1_val + q2_val
+
+    def predict(self, obs: Any, deterministic: bool = True) -> np.ndarray:
+        arr = np.asarray(obs)
+        actions = [int(np.argmax(self._get_q(tuple(row)))) for row in arr]
+        return np.array(actions)
+
+    def predict_proba(self, obs: Any) -> np.ndarray:
+        arr = np.asarray(obs)
+        prob_list = []
+        for row in arr:
+            q_vals = self._get_q(tuple(row))
+            exp_q = np.exp(q_vals - np.max(q_vals))
+            prob_list.append(exp_q / exp_q.sum())
+        return np.vstack(prob_list)

--- a/freqtrade/freqai/prediction_models/DuelingDQNClassifier.py
+++ b/freqtrade/freqai/prediction_models/DuelingDQNClassifier.py
@@ -1,0 +1,138 @@
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from freqtrade.freqai.base_models.BaseClassifierModel import BaseClassifierModel
+from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
+from freqtrade.freqai.RL.PrioritizedReplayBuffer import PrioritizedReplayBuffer
+
+
+class DuelingQNetwork(nn.Module):
+    """Simple dueling network with separate value and advantage streams."""
+
+    def __init__(self, input_dim: int, n_actions: int):
+        super().__init__()
+        self.feature = nn.Sequential(nn.Linear(input_dim, 128), nn.ReLU())
+        self.value_stream = nn.Sequential(nn.Linear(128, 128), nn.ReLU(), nn.Linear(128, 1))
+        self.adv_stream = nn.Sequential(nn.Linear(128, 128), nn.ReLU(), nn.Linear(128, n_actions))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.feature(x)
+        val = self.value_stream(x)
+        adv = self.adv_stream(x)
+        return val + adv - adv.mean(dim=1, keepdim=True)
+
+
+class DuelingDQNClassifier(BaseClassifierModel):
+    """Deep Q-network with dueling architecture and prioritized replay."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        cfg = self.freqai_info.get("rl_config", {})
+        self.gamma: float = cfg.get("gamma", 0.99)
+        self.epsilon: float = cfg.get("epsilon", 1.0)
+        self.epsilon_decay: float = cfg.get("epsilon_decay", 0.995)
+        self.min_epsilon: float = cfg.get("min_epsilon", 0.01)
+        self.batch_size: int = cfg.get("batch_size", 32)
+        self.train_cycles: int = cfg.get("train_cycles", 1)
+        self.buffer_size: int = cfg.get("buffer_size", 10_000)
+        self.lr: float = cfg.get("learning_rate", 1e-3)
+        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.n_actions: int = 0
+
+    def fit(self, data_dictionary: dict[str, Any], dk: FreqaiDataKitchen, **kwargs) -> Any:
+        X = data_dictionary["train_features"].to_numpy()
+        y = data_dictionary["train_labels"].to_numpy()[:, 0].astype(int)
+        self.n_actions = len(np.unique(y))
+        input_dim = X.shape[1]
+        policy_net = DuelingQNetwork(input_dim, self.n_actions).to(self.device)
+        target_net = DuelingQNetwork(input_dim, self.n_actions).to(self.device)
+        target_net.load_state_dict(policy_net.state_dict())
+        optimizer = optim.Adam(policy_net.parameters(), lr=self.lr)
+        buffer = PrioritizedReplayBuffer(self.buffer_size)
+
+        for _ in range(self.train_cycles):
+            for i in range(len(X) - 1):
+                state = X[i]
+                if np.random.rand() < self.epsilon:
+                    action = np.random.randint(self.n_actions)
+                else:
+                    with torch.no_grad():
+                        q_vals = policy_net(
+                            torch.tensor(state, dtype=torch.float32, device=self.device)
+                        )
+                        action = int(torch.argmax(q_vals).item())
+                reward = 1.0 if action == y[i] else 0.0
+                next_state = X[i + 1]
+                done = i == len(X) - 2
+                buffer.add(state, action, reward, next_state, done)
+
+                if len(buffer) >= self.batch_size:
+                    (
+                        states,
+                        actions,
+                        rewards,
+                        next_states,
+                        dones,
+                        idxs,
+                        weights,
+                    ) = buffer.sample(self.batch_size)
+                    states_t = torch.tensor(states, dtype=torch.float32, device=self.device)
+                    actions_t = torch.tensor(actions, dtype=torch.long, device=self.device)
+                    rewards_t = torch.tensor(rewards, dtype=torch.float32, device=self.device)
+                    next_states_t = torch.tensor(
+                        next_states, dtype=torch.float32, device=self.device
+                    )
+                    dones_t = torch.tensor(dones, dtype=torch.float32, device=self.device)
+                    weights_t = torch.tensor(weights, dtype=torch.float32, device=self.device)
+
+                    q_values = policy_net(states_t).gather(1, actions_t.unsqueeze(1)).squeeze(1)
+                    with torch.no_grad():
+                        next_actions = torch.argmax(policy_net(next_states_t), dim=1)
+                        next_q = (
+                            target_net(next_states_t)
+                            .gather(1, next_actions.unsqueeze(1))
+                            .squeeze(1)
+                        )
+                        target = rewards_t + self.gamma * next_q * (1 - dones_t)
+                    td_error = target - q_values
+                    loss = (weights_t * td_error.pow(2)).mean()
+                    optimizer.zero_grad()
+                    loss.backward()
+                    optimizer.step()
+                    buffer.update_priorities(idxs, td_error.detach().cpu().numpy())
+
+            target_net.load_state_dict(policy_net.state_dict())
+            self.epsilon = max(self.min_epsilon, self.epsilon * self.epsilon_decay)
+
+        return _DuelingPolicy(policy_net, self.device, self.n_actions)
+
+
+class _DuelingPolicy:
+    """Wrapper providing predict and predict_proba for the trained network."""
+
+    def __init__(self, network: DuelingQNetwork, device: torch.device, n_actions: int) -> None:
+        self.network = network
+        self.device = device
+        self.classes_ = np.arange(n_actions)
+
+    def predict(self, obs: Any, deterministic: bool = True) -> np.ndarray:
+        with torch.no_grad():
+            q_vals = self.network(
+                torch.tensor(np.asarray(obs), dtype=torch.float32, device=self.device)
+            )
+            actions = torch.argmax(q_vals, dim=1).cpu().numpy()
+        return actions
+
+    def predict_proba(self, obs: Any) -> np.ndarray:
+        with torch.no_grad():
+            q_vals = (
+                self.network(torch.tensor(np.asarray(obs), dtype=torch.float32, device=self.device))
+                .cpu()
+                .numpy()
+            )
+        exp_q = np.exp(q_vals - np.max(q_vals, axis=1, keepdims=True))
+        return exp_q / exp_q.sum(axis=1, keepdims=True)

--- a/freqtrade/freqai/prediction_models/TabularQLearningClassifier.py
+++ b/freqtrade/freqai/prediction_models/TabularQLearningClassifier.py
@@ -1,0 +1,77 @@
+import random
+from collections import defaultdict
+from typing import Any
+
+import numpy as np
+
+from freqtrade.freqai.base_models.BaseClassifierModel import BaseClassifierModel
+from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
+
+
+class TabularQLearningClassifier(BaseClassifierModel):
+    """Simple tabular Q-learning classifier."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        cfg = self.freqai_info.get("rl_config", {})
+        self.alpha: float = cfg.get("alpha", 0.1)
+        self.gamma: float = cfg.get("gamma", 0.99)
+        self.epsilon: float = cfg.get("epsilon", 1.0)
+        self.epsilon_decay: float = cfg.get("epsilon_decay", 0.995)
+        self.min_epsilon: float = cfg.get("min_epsilon", 0.01)
+        self.train_cycles: int = cfg.get("train_cycles", 1)
+        self.n_actions: int = 0
+
+    def _epsilon_action(
+        self, state: tuple[float, ...], q_table: dict[tuple[float, ...], np.ndarray]
+    ) -> int:
+        if random.random() < self.epsilon:
+            return random.randrange(self.n_actions)
+        return int(np.argmax(q_table[state]))
+
+    def fit(self, data_dictionary: dict[str, Any], dk: FreqaiDataKitchen, **kwargs) -> Any:
+        X = data_dictionary["train_features"].to_numpy()
+        y = data_dictionary["train_labels"].to_numpy()[:, 0].astype(int)
+        self.n_actions = len(np.unique(y))
+        q_table: dict[tuple[float, ...], np.ndarray] = defaultdict(lambda: np.zeros(self.n_actions))
+
+        for _ in range(self.train_cycles):
+            for i in range(len(X) - 1):
+                s_key = tuple(X[i])
+                ns_key = tuple(X[i + 1])
+                action = self._epsilon_action(s_key, q_table)
+                reward = 1.0 if action == y[i] else 0.0
+                q_current = q_table[s_key][action]
+                q_next = np.max(q_table[ns_key])
+                q_table[s_key][action] = q_current + self.alpha * (
+                    reward + self.gamma * q_next - q_current
+                )
+            self.epsilon = max(self.min_epsilon, self.epsilon * self.epsilon_decay)
+
+        return _QTablePolicy(q_table, self.n_actions)
+
+
+class _QTablePolicy:
+    """Policy wrapper for tabular Q-values."""
+
+    def __init__(self, table: dict[tuple[float, ...], np.ndarray], n_actions: int):
+        self.table = table
+        self.n_actions = n_actions
+        self.classes_ = np.arange(n_actions)
+
+    def _get_q(self, state: tuple[float, ...]) -> np.ndarray:
+        return self.table.get(state, np.zeros(self.n_actions))
+
+    def predict(self, obs: Any, deterministic: bool = True) -> np.ndarray:
+        arr = np.asarray(obs)
+        actions = [int(np.argmax(self._get_q(tuple(row)))) for row in arr]
+        return np.array(actions)
+
+    def predict_proba(self, obs: Any) -> np.ndarray:
+        arr = np.asarray(obs)
+        prob_list = []
+        for row in arr:
+            q_vals = self._get_q(tuple(row))
+            exp_q = np.exp(q_vals - np.max(q_vals))
+            prob_list.append(exp_q / exp_q.sum())
+        return np.vstack(prob_list)


### PR DESCRIPTION
## Summary
- add tabular Q-learning classifier using BaseClassifierModel
- implement double Q-learning classifier with proper prediction interface
- implement dueling DQN classifier with prioritized replay buffer
- add prioritized replay buffer utility

## Testing
- `pre-commit run --files freqtrade/freqai/prediction_models/TabularQLearningClassifier.py freqtrade/freqai/prediction_models/DoubleQLearningClassifier.py freqtrade/freqai/prediction_models/DuelingDQNClassifier.py freqtrade/freqai/RL/PrioritizedReplayBuffer.py`

------
https://chatgpt.com/codex/tasks/task_b_688e93648e3c8329afac78d462398923